### PR TITLE
Apply tagger rules to all MATT data fields

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -687,24 +687,23 @@ class TaggerHandler {
 
 		if (game.modules.get("monks-active-tiles")?.active) {
 			const monkActions = documentData?.flags?.["monks-active-tiles"]?.actions ?? [];
-			const names = ["location.name", "entity.name"];
-			const ids = ["location.id", "entity.id"];
 			monkActions.forEach((action, i) => {
-				for (const nameProperty of names) {
-					let locationName = foundry.utils.getProperty(action?.data, nameProperty);
-					if (locationName && locationName.startsWith("[Tagger] ")) {
-						const tags = locationName.replace("[Tagger] ", "");
-						const newTags = this.applyRules(tags).join(", ");
-						foundry.utils.setProperty(documentData, `flags.monks-active-tiles.actions.${i}.data.` + nameProperty, `[Tagger] ${newTags}`);
-					}
-				}
-
-				for (const idProperty of ids) {
-					let locationId = foundry.utils.getProperty(action?.data, idProperty);
-					if (locationId && locationId.startsWith("tagger:")) {
-						const tags = locationId.replace("tagger:", "");
-						const newTags = this.applyRules(tags).join(", ");
-						foundry.utils.setProperty(documentData, `flags.monks-active-tiles.actions.${i}.data.` + idProperty, `tagger:${newTags}`);
+				if (action?.data) {
+					for (const property of Object.keys(action?.data)) {
+						let locationName = foundry.utils.getProperty(action?.data, property + ".name");
+						if (locationName && locationName.startsWith("[Tagger] ")) {
+							const tags = locationName.replace("[Tagger] ", "");
+							const newTags = this.applyRules(tags).join(", ");
+							foundry.utils.setProperty(documentData, `flags.monks-active-tiles.actions.${i}.data.` + property + `.name`, `[Tagger] ${newTags}`);
+						}
+						
+						let locationId = foundry.utils.getProperty(action?.data, property + ".id");
+						console.log(locationId);
+						if (locationId && locationId.startsWith("tagger:")) {
+							const tags = locationId.replace("tagger:", "");
+							const newTags = this.applyRules(tags).join(", ");
+							foundry.utils.setProperty(documentData, `flags.monks-active-tiles.actions.${i}.data.` + property + `.id`, `tagger:${newTags}`);
+						}
 					}
 				}
 			});


### PR DESCRIPTION
The current implementation for applying the tagger rules to MATT fields only seems to work for `entity` and 
`location` fields. MATT (and other modules that add custom MATT actions) however use a few more names for taggable fields (in MATT e.g. there is a `token` field in the "Reset tile trigger history" action).

The changes should allow any field that includes Tagger defined documents to be updated according to the Tagger rules when a template is placed.